### PR TITLE
fix(anggota): prevent duplicate entries when adding members

### DIFF
--- a/src/modules/dosen/feature/penelitian/components/edit-modal-dosen-manual.tsx
+++ b/src/modules/dosen/feature/penelitian/components/edit-modal-dosen-manual.tsx
@@ -5,7 +5,7 @@ import Form from "@/components/molecules/form"
 import { Button } from "@/components/ui/button"
 import { jabatanFungsional } from "@/constant/jabatan-fungsional"
 import { zodResolver } from "@hookform/resolvers/zod"
-import { useSetAtom } from "jotai"
+import { useAtom } from "jotai"
 import { EditIcon } from "lucide-react"
 import { useEffect, useState } from "react"
 import { useForm } from "react-hook-form"
@@ -19,7 +19,7 @@ interface EditModalDosenManualProps {
 export default function EditModalDosenManual({
   data
 }: EditModalDosenManualProps) {
-  const setAnggota = useSetAtom(anggotaAtom)
+  const [anggota, setAnggota] = useAtom(anggotaAtom)
   const [open, isOpen] = useState(false)
   const formAnggotaManual = useForm<AnggotaSchemaType>({
     resolver: zodResolver(anggotaSchema),
@@ -42,8 +42,21 @@ export default function EditModalDosenManual({
     formAnggotaManual.reset(data)
   }, [data, formAnggotaManual])
 
-  const onSubmitAnggotaManual = (data: AnggotaSchemaType) => {
-    setAnggota(prevAnggota => [...prevAnggota, data])
+  const onSubmitAnggotaManual = (formData: AnggotaSchemaType) => {
+    // Check for duplicate data based on NIDN (unique identifier)
+    const existingIndex = anggota.findIndex(item => item.nidn === formData.nidn)
+
+    if (existingIndex === -1) {
+      // Add new data if no duplicate found
+      setAnggota(prevAnggota => [...prevAnggota, formData])
+    } else {
+      // Replace existing data when duplicate is found
+      setAnggota(prevAnggota =>
+        prevAnggota.map((item, index) =>
+          index === existingIndex ? formData : item
+        )
+      )
+    }
     isOpen(false)
     formAnggotaManual.reset()
   }

--- a/src/modules/dosen/feature/penelitian/components/edit-modal-mahasiswa-manual.tsx
+++ b/src/modules/dosen/feature/penelitian/components/edit-modal-mahasiswa-manual.tsx
@@ -3,7 +3,7 @@ import Modal from "@/components/atom/modal"
 import Form from "@/components/molecules/form"
 import { Button } from "@/components/ui/button"
 import { zodResolver } from "@hookform/resolvers/zod"
-import { useSetAtom } from "jotai"
+import { useAtom } from "jotai"
 import { EditIcon } from "lucide-react"
 import { useEffect, useState } from "react"
 import { useForm } from "react-hook-form"
@@ -17,7 +17,7 @@ interface EditModalMahasiswaManualProps {
 export default function EditModalMahasiswaManual({
   data
 }: EditModalMahasiswaManualProps) {
-  const setAnggota = useSetAtom(anggotaAtom)
+  const [anggota, setAnggota] = useAtom(anggotaAtom)
   const [open, setOpen] = useState(false)
   const formMahasiswaManual = useForm<AnggotaSchemaType>({
     resolver: zodResolver(anggotaSchema),
@@ -40,8 +40,21 @@ export default function EditModalMahasiswaManual({
     formMahasiswaManual.reset(data)
   }, [data, formMahasiswaManual])
 
-  const onSubmitMahasiswaManual = (data: AnggotaSchemaType) => {
-    setAnggota(prevMahasiswa => [...prevMahasiswa, data])
+  const onSubmitMahasiswaManual = (formData: AnggotaSchemaType) => {
+    // Check for duplicate data based on NIDN (unique identifier)
+    const existingIndex = anggota.findIndex(item => item.nidn === formData.nidn)
+
+    if (existingIndex === -1) {
+      // Add new data if no duplicate found
+      setAnggota(prevAnggota => [...prevAnggota, formData])
+    } else {
+      // Replace existing data when duplicate is found
+      setAnggota(prevAnggota =>
+        prevAnggota.map((item, index) =>
+          index === existingIndex ? formData : item
+        )
+      )
+    }
     setOpen(false)
     formMahasiswaManual.reset()
   }

--- a/src/modules/dosen/feature/pengabdian/components/edit-modal-dosen-manual.tsx
+++ b/src/modules/dosen/feature/pengabdian/components/edit-modal-dosen-manual.tsx
@@ -5,7 +5,7 @@ import Form from "@/components/molecules/form"
 import { Button } from "@/components/ui/button"
 import { jabatanFungsional } from "@/constant/jabatan-fungsional"
 import { zodResolver } from "@hookform/resolvers/zod"
-import { useSetAtom } from "jotai"
+import { useAtom } from "jotai"
 import { EditIcon } from "lucide-react"
 import { useEffect, useState } from "react"
 import { useForm } from "react-hook-form"
@@ -17,7 +17,7 @@ interface ModalDosenManual {
 }
 
 export default function EditModalDosenManual({ data }: ModalDosenManual) {
-  const setAnggota = useSetAtom(anggotaAtom)
+  const [anggota, setAnggota] = useAtom(anggotaAtom)
   const [openModalManual, setOpenModalManual] = useState(false)
   const formAnggotaManual = useForm<AnggotaSchemaType>({
     resolver: zodResolver(anggotaSchema),
@@ -40,8 +40,22 @@ export default function EditModalDosenManual({ data }: ModalDosenManual) {
     formAnggotaManual.reset(data)
   }, [data, formAnggotaManual])
 
-  const onSubmitAnggotaManual = (data: AnggotaSchemaType) => {
-    setAnggota(prevAnggota => [...prevAnggota, data])
+  const onSubmitAnggotaManual = (formData: AnggotaSchemaType) => {
+    // Check for duplicate data based on NIDN (unique identifier)
+    const existingIndex = anggota.findIndex(item => item.nidn === formData.nidn)
+
+    if (existingIndex === -1) {
+      // Add new data if no duplicate found
+      setAnggota(prevAnggota => [...prevAnggota, formData])
+    } else {
+      // Replace existing data when duplicate is found
+      setAnggota(prevAnggota =>
+        prevAnggota.map((item, index) =>
+          index === existingIndex ? formData : item
+        )
+      )
+    }
+
     setOpenModalManual(false)
     formAnggotaManual.reset()
   }

--- a/src/modules/dosen/feature/pengabdian/components/edit-modal-mahasiswa-manual.tsx
+++ b/src/modules/dosen/feature/pengabdian/components/edit-modal-mahasiswa-manual.tsx
@@ -3,7 +3,7 @@ import Modal from "@/components/atom/modal"
 import Form from "@/components/molecules/form"
 import { Button } from "@/components/ui/button"
 import { zodResolver } from "@hookform/resolvers/zod"
-import { useSetAtom } from "jotai"
+import { useAtom } from "jotai"
 import { EditIcon } from "lucide-react"
 import { useEffect, useState } from "react"
 import { useForm } from "react-hook-form"
@@ -17,7 +17,7 @@ interface ModalMahasiswaManual {
 export default function EditModalMahasiswaManual({
   data
 }: ModalMahasiswaManual) {
-  const setAnggota = useSetAtom(anggotaAtom)
+  const [anggota, setAnggota] = useAtom(anggotaAtom)
   const [open, setOpen] = useState(false)
   const formMahasiswaManual = useForm<AnggotaSchemaType>({
     resolver: zodResolver(anggotaSchema),
@@ -40,8 +40,21 @@ export default function EditModalMahasiswaManual({
     formMahasiswaManual.reset(data)
   }, [data, formMahasiswaManual])
 
-  const onSubmitMahasiswaManual = (data: AnggotaSchemaType) => {
-    setAnggota(prevMahasiswa => [...prevMahasiswa, data])
+  const onSubmitMahasiswaManual = (formData: AnggotaSchemaType) => {
+    // Check for duplicate data based on NIDN (unique identifier)
+    const existingIndex = anggota.findIndex(item => item.nidn === formData.nidn)
+
+    if (existingIndex === -1) {
+      // Add new data if no duplicate found
+      setAnggota(prevAnggota => [...prevAnggota, formData])
+    } else {
+      // Replace existing data when duplicate is found
+      setAnggota(prevAnggota =>
+        prevAnggota.map((item, index) =>
+          index === existingIndex ? formData : item
+        )
+      )
+    }
     setOpen(false)
     formMahasiswaManual.reset()
   }


### PR DESCRIPTION
The changes replace useSetAtom with useAtom to access current state and add duplicate checking logic based on NIDN. When duplicate is found, existing entry is updated instead of adding a new one. This applies to both dosen and mahasiswa edit modals in penelitian and pengabdian features.